### PR TITLE
ci: run forge snapshot with NO_COLOR=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For example, to add the output of `forge snapshot` to a summary, you would chang
 
 ```yml
 - name: Run snapshot
-  run: forge snapshot >> $GITHUB_STEP_SUMMARY
+  run: NO_COLOR=1 forge snapshot >> $GITHUB_STEP_SUMMARY
 ```
 
 See the offical [GitHub docs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary) for more information.


### PR DESCRIPTION
Since the format of snapshot output messes slightly with the markdown output for GitHub steps summary. Related issue: https://github.com/foundry-rs/foundry/issues/3394.