### PR TITLE
Fix branding color

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Install Foundry'
 author: 'Oliver Nordbjerg'
 branding:
   icon: play-circle
-  color: black
+  color: gray-dark
 inputs:
   version:
     description: |


### PR DESCRIPTION
As mentioned in the [`branding.color`](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#brandingcolor) docs, `black` is not an option.

I have changed it to `gray-dark`, which seems to be the closest to black.