### PR TITLE
Make input not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## `foundry-toolchain` Action
 
-This GitHub Action installs [Foundry](https://github.com/foundry-rs/foundry).
+This GitHub Action installs [Foundry](https://github.com/foundry-rs/foundry), the blazing fast, portable and modular toolkit for Ethereum application development.
 
 ### Example workflow
 
@@ -20,8 +20,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
 
       - name: Run tests
         run: forge test -vvv
@@ -32,10 +30,9 @@ jobs:
 
 ### Inputs
 
-| **Name**  | **Required** | **Description**                                                                                               | **Type** |
-|-----------|--------------|---------------------------------------------------------------------------------------------------------------|----------|
-| `version` | Yes          | Version to install, e.g. `nightly` or `1.0.0`.  **Note:** Foundry only has nightly builds for the time being. | string   |
-
+| **Name**  | **Required** | **Default** | **Description**                                                                                              | **Type** |
+| --------- | ------------ | ----------- | ------------------------------------------------------------------------------------------------------------ | -------- |
+| `version` | No           | `nightly`   | Version to install, e.g. `nightly` or `1.0.0`. **Note:** Foundry only has nightly builds for the time being. | string   |
 
 ### Summaries
 
@@ -48,4 +45,4 @@ For example, to add the output of `forge snapshot` to a summary, you would chang
   run: NO_COLOR=1 forge snapshot >> $GITHUB_STEP_SUMMARY
 ```
 
-See the offical [GitHub docs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary) for more information.
+See the official [GitHub docs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary) for more information.

--- a/action.yml
+++ b/action.yml
@@ -1,17 +1,20 @@
-name: 'foundry-toolchain'
-description: 'Install Foundry'
-author: 'Oliver Nordbjerg'
+name: "foundry-toolchain"
+description: "Install Foundry"
+author: "Oliver Nordbjerg"
 branding:
-  icon: play-circle
-  color: gray-dark
+  color: "gray-dark"
+  icon: "play-circle"
+  
 inputs:
   version:
+    default: "nightly"
     description: |
       Foundry version.
 
       This version number has to match a released version of Foundry.
       Alternatively you can also specify `nightly` for the latest nightly build.
+    required: false
 
 runs:
-  using: node16
-  main: dist/index.js
+  using: "node16"
+  main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Install Foundry'
 author: 'Oliver Nordbjerg'
 branding:
   icon: play-circle
-  color: black
+  color: gray-dark
 inputs:
   version:
     description: |


### PR DESCRIPTION
This PR makes the `version` input non-required, defaulting to `nightly`. I think that this is a sensible thing to do now, given that Foundry is in active development and only has nightly releases. We might revert back to this later on when Foundry starts releasing stable versions as well.

Full changelog:

- refactor: make "version" input not required
- chore: use double quotes in "action.yml"
- docs: add brief description about Foundry in README
- docs: fix typos in README
- docs: remove optional input "version" from example script
- refactor: set "nightly" as default value for "version"