### PR TITLE
DO NOT MERGE: start defaulting to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ jobs:
 
 ### Inputs
 
-| **Name**             | **Required** | **Default**                           | **Description**                                                                                              | **Type** |
-| -------------------- | ------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------- |
-| `cache`              | No           | `true`                                | Whether to cache RPC responses or not.                                                                       | bool     |
-| `version`            | No           | `nightly`                             | Version to install, e.g. `nightly` or `1.0.0`. **Note:** Foundry only has nightly builds for the time being. | string   |
-| `cache-key`          | No           | `${{ github.job }}-${{ github.sha }}` | The cache key to use for caching.                                                                            | string   |
-| `cache-restore-keys` | No           | `[${{ github.job }}-]`                | The cache keys to use for restoring the cache.                                                               | string[] |
+| **Name**             | **Required** | **Default**                           | **Description**                                          | **Type** |
+| -------------------- | ------------ | ------------------------------------- | -------------------------------------------------------- | -------- |
+| `cache`              | No           | `true`                                | Whether to cache RPC responses or not.                   | bool     |
+| `version`            | No           | `stable`                              | Version to install, e.g. `stable`, `nightly` or `1.0.0`. | string   |
+| `cache-key`          | No           | `${{ github.job }}-${{ github.sha }}` | The cache key to use for caching.                        | string   |
+| `cache-restore-keys` | No           | `[${{ github.job }}-]`                | The cache keys to use for restoring the cache.           | string[] |
 
 ### RPC Caching
 

--- a/action.yml
+++ b/action.yml
@@ -29,12 +29,12 @@ inputs:
       This key is used to identify the cache to restore. If not provided, a default key consisting of the job id is used.
     required: false
   version:
-    default: "nightly"
+    default: "stable"
     description: |
       Foundry version.
 
       This version number has to match a released version of Foundry.
-      The default value is `nightly`, which will pull the latest nightly build.
+      The default value is `stable`, which will pull the latest stable build.
     required: false
 
 runs:


### PR DESCRIPTION
DO NOT MERGE

For our stable release, update the Foundry toolchain to point to the latest stable version by default.
The plan is to create a release tag aliased with `stable`, in the same way we alias `nightly`.