### PR TITLE
chore(`ci`): rescope permissions according to principle of least privilege

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: ci
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   pull_request:
@@ -22,6 +21,8 @@ concurrency:
 jobs:
   match:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,7 @@
 name: CodeQL
 
+permissions: {}
+
 on:
   push:
     branches: ["master"]


### PR DESCRIPTION
By assigning

```
permissions: {}
```

we disable all permissions by default

we then grant it on a per-job basis to exactly what is strictly required