### PR TITLE
docs: remove rc from documented version options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
 
 | **Name**             | **Required** | **Default**                           | **Description**                                                                                                                                       | **Type** |
 | -------------------- | ------------ | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `version`            | No           | `stable`                              | Version to install, e.g. `stable`, `rc`, `nightly` or any [SemVer](https://semver.org/) version with or without `v` prefix (e.g. `v1.5.0` or `1.5.0`) | string   |
+| `version`            | No           | `stable`                              | Version to install, e.g. `stable`, `nightly` or any [SemVer](https://semver.org/) version with or without `v` prefix (e.g. `v1.5.0` or `1.5.0`)       | string   |
 | `cache`              | No           | `true`                                | Whether to cache Foundry data or not.                                                                                                                 | bool     |
 | `cache-key`          | No           | `${{ github.job }}-${{ github.sha }}` | The cache key to use for caching.                                                                                                                     | string   |
 | `cache-restore-keys` | No           | `[${{ github.job }}-]`                | The cache keys to use for restoring the cache.                                                                                                        | string[] |

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
 
       This version number has to match a released version of Foundry.
       The default value is `stable`, which will pull the latest stable build.
-      Other options include `nightly`, `rc`, or a specific version like `v1.3.6`.
+      Other options include `nightly` or a specific version like `v1.3.6`.
     required: false
   network:
     default: "ethereum"


### PR DESCRIPTION
Removes `rc` from the documented `version` input options, since it is no longer a supported channel after foundry-rs/foundry#14445 (immutable releases).

## Context

The Foundry release workflow previously supported a mutable `rc` Git tag that was force-moved on each release candidate. With the immutable releases PR (foundry-rs/foundry#14445), the `rc` channel is removed — release candidates are now pre-release tags like `v1.6.0-rc1` and must be installed by their explicit version.

## Changes

- `action.yml`: removed `rc` from the version description
- `README.md`: removed `rc` from the inputs table

## Behavior change for users

Once foundry-rs/foundry#14445 merges:

- `version: rc` → no longer works; users must pin the specific version (e.g. `version: v1.6.0-rc1`)
- `version: stable` (default) → silently changes meaning, now resolves via GitHub `/releases/latest`. Until `v1.7.0` is tagged, this returns `v1.6.0-rc1` because GitHub considers it the latest non-prerelease release
- `version: nightly` → still works (resolves to latest `nightly-{SHA}`)
- `version: v1.6.0` / `1.6.0` → still works

## Related

- foundry-rs/foundry#14445 — Foundry immutable releases PR