### PR TITLE
ci: update dist on dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-dist.yml
+++ b/.github/workflows/dependabot-dist.yml
@@ -1,0 +1,56 @@
+name: dependabot dist
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    paths:
+      - package.json
+      - pnpm-lock.yaml
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  update-dist:
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: true
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Rebuild dist/
+        run: pnpm run build
+
+      - name: Commit dist/ update
+        run: |
+          if git diff --quiet -- dist/; then
+            exit 0
+          fi
+
+          git config user.name "dependabot[bot]"
+          git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
+          git add dist/
+          git commit -m "chore(deps): update dist"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
Adds a Dependabot-only workflow that rebuilds committed dist artifacts for npm dependency updates and pushes the result back to the Dependabot PR branch when dist changes.

Prompted by: @DaniPopes