### PR TITLE
ci: allow dependabot dist after maintainer updates

### DIFF
--- a/.github/workflows/dependabot-dist.yml
+++ b/.github/workflows/dependabot-dist.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   update-dist:
     if: >-
-      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The dependabot dist job checked github.actor, so it skipped after a maintainer or agent pushed an update to a Dependabot PR branch. Check the pull request author instead while keeping the same-repository guard.

Prompted by: @DaniPopes